### PR TITLE
fix(assets): Download fonts as offline assets

### DIFF
--- a/.generator/generate.py
+++ b/.generator/generate.py
@@ -28,7 +28,7 @@ MODULE_CONFIG = {
         ),
     ],
     "styles": [
-        "https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons",
+        "fonts.css",
         "https://cdn.jsdelivr.net/npm/quasar@2.12.4/dist/quasar.prod.css",
     ],
     "vue_use": ["Quasar"],

--- a/.generator/get_fonts.py
+++ b/.generator/get_fonts.py
@@ -1,0 +1,23 @@
+# search "./.download/fonts_with_urls.css" for remote assets and download them
+# produce a new file with "./generator/fonts.css" local paths instead of remote
+# this script should run on the top-level directory of the project
+
+import re
+from pathlib import Path
+from urllib.request import urlretrieve
+from urllib.parse import urlparse
+
+ROOT = Path(__file__).parent.parent.absolute()
+
+pattern = re.compile("http[^)]*")  # capture from http until a parenthesis ')'
+with open(ROOT / ".download/fonts_with_urls.css", "r") as fonts:
+    lines = fonts.read()
+    new_lines = lines
+    for url in pattern.finditer(lines):
+        parsed_url = urlparse(url[0]).path
+        destination = Path(parsed_url).name
+        urlretrieve(url[0], str(ROOT / ".generator" / destination))
+        new_lines = re.sub(url[0], f'"{destination}"', new_lines)
+
+    with open(ROOT / ".generator/fonts.css", "w") as out:
+        out.write(new_lines)

--- a/.generator/run.sh
+++ b/.generator/run.sh
@@ -1,5 +1,10 @@
 QUASAR_URL=https://registry.npmjs.org/quasar/-/quasar-2.12.4.tgz
+FONTS_URL="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900|Material+Icons"
 mkdir -p .download && cd .download && curl -L $QUASAR_URL | tar --strip-components=1 -xzv
 cd ..
 python ./.generator/generate.py
+curl -o ./.download/fonts_with_urls.css "$FONTS_URL"
+python ./.generator/get_fonts.py
+
 python -m trame.tools.widgets --config ./.generator/config.yaml --output ./
+mv ./.generator/*.ttf ./trame_quasar/module/quasar/vue3/


### PR DESCRIPTION
When quasar is used with tauri, the bundled application does
not have access to the internet so it cannot fetch remote components of the css.
To avoid this issue we extract and bundle the fonts used by this module